### PR TITLE
Show popular prototypes

### DIFF
--- a/app/controllers/prototypes/popular_controller.rb
+++ b/app/controllers/prototypes/popular_controller.rb
@@ -1,0 +1,8 @@
+class Prototypes::PopularController < ApplicationController
+
+  def index
+    @prototypes = Prototype.likes_desc
+    render template: "prototypes/index"
+  end
+
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -7,6 +7,8 @@ class Prototype < ActiveRecord::Base
 
   validates_presence_of :name, :catchcopy, :concept
 
+  scope :likes_desc, -> {order('like_count desc')}
+
   def reject_image(attributed)
     attributed['image_url'].blank?
   end

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -14,7 +14,7 @@
 
 .container.proto-list
   .row
-    = render @prototypes
+    = render partial: "prototypes/prototype", collection: @prototypes
 .text-center
   %ul.pagination
     %li.disabled

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -7,7 +7,7 @@
     .row
       %ul.nav.nav-pills.col-lg-11
         %li.active{role: "presentation"}
-          %a{href: popular_index_path } Popular PROTO
+          = link_to "Popular PROTO", popular_index_path
         %li{role: "presentation"}
           %a{href: "#"} Newest PROTO
       %button{type: "button", class: "btn btn-default col-lg-1"} View Tags

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -7,7 +7,7 @@
     .row
       %ul.nav.nav-pills.col-lg-11
         %li.active{role: "presentation"}
-          %a{href: "#"} Popular PROTO
+          %a{href: popular_index_path } Popular PROTO
         %li{role: "presentation"}
           %a{href: "#"} Newest PROTO
       %button{type: "button", class: "btn btn-default col-lg-1"} View Tags

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,15 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :users, only: [:edit, :show, :update]
   root to: 'prototypes#index'
+  resources :users, only: [:edit, :show, :update]
   resources :prototypes do
     resources :likes, only: [:create, :destroy]
     resources :comments, only: :create
+  end
+
+  # resources :prototypes
+  scope module: :prototypes do
+    resources :popular, only: :index
   end
 
   # get  '/prototypes/index'  =>    'prototypes#index'


### PR DESCRIPTION
# WHAT

Show popular prototypes
# WHY

To make it easy for users to distinguish which prototype is most popular.
